### PR TITLE
use kotlin compilerOptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+
 buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
@@ -18,12 +21,10 @@ plugins {
 
 sourceCompatibility = 17
 
-compileKotlin {
-    kotlinOptions.jvmTarget = "17"
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "17"
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_17
+  }
 }
 
 gradlePlugin {


### PR DESCRIPTION
# Motivation

`kotlinOptions` is deprecated.  Let's use kotlin `compilerOptions` instead

# Context

https://www.reddit.com/r/Kotlin/comments/1eb2utz/kotlinoptions_is_deprecated/

https://kotlinlang.org/docs/gradle-compiler-options.html#migrate-from-kotlinoptions-to-compileroptions

